### PR TITLE
Fix package.json homepage link

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/hmsk/vite-plugin-markdown/issues"
   },
-  "homepage": "https://github.com/hmsk/vite-plugin-markdown/tree/master/#readme",
+  "homepage": "https://github.com/hmsk/vite-plugin-markdown/tree/main/#readme",
   "dependencies": {
     "front-matter": "^4.0.0",
     "htmlparser2": "^4.1.0",


### PR DESCRIPTION
The homepage property in package.json was linked to master branch which does not exists.
This PR fixes this.
