### PR TITLE
Change module.exports to es2015 export

### DIFF
--- a/examples/react/vite.config.js
+++ b/examples/react/vite.config.js
@@ -1,13 +1,13 @@
 // @ts-check
 const reactPlugin = require('vite-plugin-react')
-const mdPlugin = require('vite-plugin-markdown')
+const { markdownPlugin, Mode } = require('vite-plugin-markdown')
 
 /**
  * @type { import('vite').UserConfig }
  */
 const config = {
   jsx: 'react',
-  plugins: [reactPlugin, mdPlugin({ mode: ['html', 'toc', 'react'] })]
+  plugins: [reactPlugin, markdownPlugin({ mode: [Mode.HTML, Mode.TOC, Mode.REACT] })]
 }
 
 module.exports = config

--- a/examples/vue/vite.config.js
+++ b/examples/vue/vite.config.js
@@ -1,11 +1,11 @@
 // @ts-check
-const fmPlugin = require('vite-plugin-markdown')
+const { markdownPlugin, Mode } = require('vite-plugin-markdown')
 
 /**
  * @type { import('vite').UserConfig }
  */
 const config = {
-  plugins: [fmPlugin({ mode: ['html', 'toc', 'vue'] })]
+  plugins: [markdownPlugin({ mode: [Mode.HTML, Mode.TOC, Mode.VUE] })]
 }
 
 module.exports = config

--- a/package-lock.json
+++ b/package-lock.json
@@ -502,9 +502,9 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-13.0.0.tgz",
-      "integrity": "sha512-Anxc3qgkAi7peAyesTqGYidG5GRim9jtg8xhmykNaZkImtvjA7Wsqep08D2mYsqw1IF7rA3lYfciLgzUSgRoqw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-14.0.0.tgz",
+      "integrity": "sha512-+PSmD9ePwTAeU106i9FRdc+Zb3XUWyW26mo5Atr2mk82hor8+nPwkztEjFo8/B1fJKfaQDg9aM2bzQkjhi7zOw==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.0.8",
@@ -526,18 +526,18 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.1.0.tgz",
-      "integrity": "sha512-ovq7ZM3JJYUUmEjjO+H8tnUdmQmdQudJB7xruX8LFZ1W2q8jXdPUS6SsIYip8ByOApu4RR7729Am9WhCeCMiHA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.4.0.tgz",
+      "integrity": "sha512-LFqKdRLn0ShtQyf6SBYO69bGE1upV6wUhBX0vFOUnLAyzx5cwp8svA0eHUnu8+YU57XOkrMtfG63QOpQx25pHQ==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^3.0.8",
-        "@types/resolve": "0.0.8",
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
         "builtin-modules": "^3.1.0",
         "deep-freeze": "^0.0.1",
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
-        "resolve": "^1.14.2"
+        "resolve": "^1.17.0"
       }
     },
     "@rollup/pluginutils": {
@@ -625,9 +625,9 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.7.tgz",
+      "integrity": "sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -637,9 +637,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
-      "integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
+      "version": "4.17.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz",
+      "integrity": "sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -718,21 +718,21 @@
       "dev": true
     },
     "@types/mime": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
-      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
+      "version": "14.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA==",
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==",
       "dev": true
     },
     "@types/range-parser": {
@@ -742,18 +742,18 @@
       "dev": true
     },
     "@types/resolve": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/serve-static": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
-      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
+      "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
       "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
@@ -860,34 +860,34 @@
       }
     },
     "@vue/compiler-core": {
-      "version": "3.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.0-beta.18.tgz",
-      "integrity": "sha512-3JSSCs11lYuNdfyT5DVB06OeWlT/aAK8JKHLmG8OsXkT0flVSc19mtnqi+EaFhW3rT63qT0fjJfTfU0Wn1PN9Q==",
+      "version": "3.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.0-rc.5.tgz",
+      "integrity": "sha512-dNz5AObEYg0Oglw3emIsBhTAOVfObrfxDaAzR0UTRDDq+Ohfr6KTSaVQAH88Ym+oa08ZlLZBFc6ARe9doAOIxg==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6",
-        "@vue/shared": "3.0.0-beta.18",
-        "estree-walker": "^0.8.1",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4",
+        "@vue/shared": "3.0.0-rc.5",
+        "estree-walker": "^2.0.1",
         "source-map": "^0.6.1"
       },
       "dependencies": {
         "estree-walker": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.8.1.tgz",
-          "integrity": "sha512-H6cJORkqvrNziu0KX2hqOMAlA2CiuAxHeGJXSIoKA/KLv229Dw806J3II6mKTm5xiDX1At1EXCfsOQPB+tMB+g==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+          "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
           "dev": true
         }
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.18.tgz",
-      "integrity": "sha512-vTfZNfn/bfGVJCdQwQN5xeBIaFCYPKp/NZCyMewh0wdju2ewzSmQIzG3gaSqEIxYor/FQmFkGuRRzWJJBmcoUQ==",
+      "version": "3.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.0-rc.5.tgz",
+      "integrity": "sha512-z8n+R1GhFnWuKURLYxfVSEfP7nSNM91qteobxwys55fhlZZuReouMnUwgrn+ois/IL6RdFlT9H+n4+N6yLrdJA==",
       "dev": true,
       "requires": {
-        "@vue/compiler-core": "3.0.0-beta.18",
-        "@vue/shared": "3.0.0-beta.18"
+        "@vue/compiler-core": "3.0.0-rc.5",
+        "@vue/shared": "3.0.0-rc.5"
       }
     },
     "@vue/compiler-sfc": {
@@ -999,39 +999,39 @@
       }
     },
     "@vue/reactivity": {
-      "version": "3.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.0-beta.18.tgz",
-      "integrity": "sha512-UFKONXh5XZCwynGrS6CAYTz3AoNVmLUpuQnfl3z8XbHulw9kqVwFoQgXwFBlrizdLsPoNW0s3FHPmtqC9Ohjgg==",
+      "version": "3.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.0-rc.5.tgz",
+      "integrity": "sha512-oe9C+1jtWUdYL/iNc0OPWbwgOk2rOW2uQ+exx3I6Jo6PKOmnAiPkMElalf9vRnO53rnUphVecMp8BlTJvcNgDw==",
       "dev": true,
       "requires": {
-        "@vue/shared": "3.0.0-beta.18"
+        "@vue/shared": "3.0.0-rc.5"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.0-beta.18.tgz",
-      "integrity": "sha512-ZgIxCSuR1luq3pmWQbsYkn6ybUK/BKAWRQwAxUCP9BjFHnvN0W4BSLwy6VuH2l2ToKGni+xPxpDZhQQQsVAfng==",
+      "version": "3.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.0-rc.5.tgz",
+      "integrity": "sha512-MRIWreFigxdRuI2moFociUL5rVBfgYPrT7rWfQ0XfOyW46b+AiuCJyZvgbsRXwkAERfW1Tb/mY5forYjX2thOg==",
       "dev": true,
       "requires": {
-        "@vue/reactivity": "3.0.0-beta.18",
-        "@vue/shared": "3.0.0-beta.18"
+        "@vue/reactivity": "3.0.0-rc.5",
+        "@vue/shared": "3.0.0-rc.5"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.0-beta.18.tgz",
-      "integrity": "sha512-2ym4EyWg1C/UDXuVjFyqwLgAjrWRTRM3wHBmp0TlpoXSSNvIEJg5HXRgC1jnHtkVbGmyHHPndsbFP+oBj10tzQ==",
+      "version": "3.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.0-rc.5.tgz",
+      "integrity": "sha512-0jwpO3MBqMToq7qC816Z8Y6G8aN4ZKbv7MupgRaepzxhiK0sXcjLQmOATP3g/NyX52UCBJS4wAwsxidqGnAabA==",
       "dev": true,
       "requires": {
-        "@vue/runtime-core": "3.0.0-beta.18",
-        "@vue/shared": "3.0.0-beta.18",
+        "@vue/runtime-core": "3.0.0-rc.5",
+        "@vue/shared": "3.0.0-rc.5",
         "csstype": "^2.6.8"
       }
     },
     "@vue/shared": {
-      "version": "3.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.0-beta.18.tgz",
-      "integrity": "sha512-wRvQaTHeCt3xxqj3UpMR2JxkkU7ul/9RMqSxGJhOd4Bsp72Md4H83XkijHy8LkPKZWszmxjEpfCYuw9MU0a4kg==",
+      "version": "3.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.0-rc.5.tgz",
+      "integrity": "sha512-ZhcgGzBpp+pUzisZgQpM4ctIGgLpYjBj7/rZfbhEPxFHF/BuTV2jmhXvAl8aF9xDAejIcw85xCy92gDSwKtPag==",
       "dev": true
     },
     "accepts": {
@@ -1372,9 +1372,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -1412,9 +1412,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.3.0.tgz",
-      "integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
+      "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
       "dev": true
     },
     "cli-table3": {
@@ -1647,9 +1647,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
-      "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
+      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==",
       "dev": true
     },
     "cypress": {
@@ -2080,9 +2080,9 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.5.19.tgz",
-      "integrity": "sha512-QiK0BCLPemNO9zziNOFudQbtNnEax/x8faBfbtEtfhb53gNk0H5J10uFrzmJef1P379VrP66BZpc02iqBuM/+g==",
+      "version": "0.6.24",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.6.24.tgz",
+      "integrity": "sha512-usGuyo+DpQmrTguh/IOK8DBAvQ4CU7xdDtr7h/2iEK/BwBdrkpxut/uYzYaRh6ljMSSZWVJdaQgu2aOgz7m6ag==",
       "dev": true
     },
     "escape-html": {
@@ -2284,9 +2284,9 @@
       "dev": true
     },
     "execa": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-      "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
@@ -2463,9 +2463,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
-      "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
       "dev": true
     },
     "forever-agent": {
@@ -3235,26 +3235,14 @@
       }
     },
     "koa-send": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.0.tgz",
-      "integrity": "sha512-90ZotV7t0p3uN9sRwW2D484rAaKIsD8tAVtypw/aBU+ryfV+fR2xrcAwhI8Wl6WRkojLUs/cB9SBSCuIb+IanQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
+      "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "http-errors": "^1.6.3",
-        "mz": "^2.7.0",
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
         "resolve-path": "^1.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "koa-static": {
@@ -3821,9 +3809,9 @@
       "dev": true
     },
     "open": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.0.4.tgz",
-      "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.1.0.tgz",
+      "integrity": "sha512-lLPI5KgOwEYCDKXf4np7y1PBEkj7HYIyP2DY8mVDRnx0VIIu6bNrRB0R66TuO7Mack6EnTNLm4uvcl1UoklTpA==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -3845,9 +3833,9 @@
       }
     },
     "ora": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz",
-      "integrity": "sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
@@ -4400,18 +4388,18 @@
       }
     },
     "rollup": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.18.2.tgz",
-      "integrity": "sha512-+mzyZhL9ZyLB3eHBISxRNTep9Z2qCuwXzAYkUbFyz7yNKaKH03MFKeiGOS1nv2uvPgDb4ASKv+FiS5mC4h5IFQ==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.1.tgz",
+      "integrity": "sha512-02YjpGeUJNRQtxGrwX79gDnrNonu9Gu6eu1cgXcvj3rqqN5lr6Erl3t1yYtnexdEvPAfI32PBALYyAbdsBsL8A==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
       }
     },
     "rollup-plugin-dynamic-import-variables": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dynamic-import-variables/-/rollup-plugin-dynamic-import-variables-1.0.2.tgz",
-      "integrity": "sha512-bzYC/MwYsHgNGpWMI3G4qTjstJCtFqE25/k1Cq/sjfnzl7MQwwrrA4SAQEMiFgKbsw1H4tijVGY1tRk5Xa4h9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dynamic-import-variables/-/rollup-plugin-dynamic-import-variables-1.1.0.tgz",
+      "integrity": "sha512-C1avEmnXC8cC4aAQ5dB63O9oQf7IrhEHc98bQw9Qd6H36FxtZooLCvVfcO4SNYrqaNrzH3ErucQt/zdFSLPHNw==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.0.9",
@@ -4442,9 +4430,9 @@
       }
     },
     "rollup-plugin-vue": {
-      "version": "6.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0-beta.6.tgz",
-      "integrity": "sha512-APbkp9EDk0Vj5PpZNaa11yyNhr/Uy8OkrzpkajxUvONU+S7+qqOSVlaNTcsxiT198dOC6TM0iJK5ChDgEVecTA==",
+      "version": "6.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0-beta.10.tgz",
+      "integrity": "sha512-8TZJmROiSRjWoHRR6id0/ktOBOUGuI302xDBq4YBiA/tnnXdoY3oFGtvRWzT5ldX0jTJ8QX40rrJOw2SvcWwxQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -4987,19 +4975,19 @@
       }
     },
     "vite": {
-      "version": "1.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-1.0.0-beta.11.tgz",
-      "integrity": "sha512-etweuuPXgxwruCrcyj63fwpUlc6+HsE4n7uiOQ/fYEzjwOrUtEX4BuVAYcSkoxVA8qHS7zukG4LYzIozcD92Xw==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-1.0.0-rc.4.tgz",
+      "integrity": "sha512-D9gpKKaE2U0YpIxNrSn+nlFPBT0sfg68Y1EReYW8YHMhbNFcxwS7RZIa1W/8Pq6yDfVRAhbOZNijv1mLG5pCEg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
-        "@rollup/plugin-commonjs": "^13.0.0",
+        "@rollup/plugin-commonjs": "^14.0.0",
         "@rollup/plugin-json": "^4.0.3",
-        "@rollup/plugin-node-resolve": "^8.0.0",
+        "@rollup/plugin-node-resolve": "^8.4.0",
         "@types/koa": "^2.11.3",
         "@types/lru-cache": "^5.1.0",
-        "@vue/compiler-dom": "^3.0.0-beta.14",
-        "@vue/compiler-sfc": "^3.0.0-beta.14",
+        "@vue/compiler-dom": "^3.0.0-rc.5",
+        "@vue/compiler-sfc": "^3.0.0-rc.5",
         "brotli-size": "^4.0.0",
         "chalk": "^4.0.0",
         "chokidar": "^3.3.1",
@@ -5008,7 +4996,7 @@
         "dotenv": "^8.2.0",
         "dotenv-expand": "^5.1.0",
         "es-module-lexer": "^0.3.18",
-        "esbuild": "^0.5.11",
+        "esbuild": "^0.6.10",
         "etag": "^1.8.1",
         "execa": "^4.0.1",
         "fs-extra": "^9.0.0",
@@ -5032,26 +5020,27 @@
         "postcss-import": "^12.0.1",
         "postcss-load-config": "^2.1.0",
         "resolve": "^1.17.0",
-        "rollup": "^2.11.2",
+        "rollup": "^2.20.0",
         "rollup-plugin-dynamic-import-variables": "^1.0.1",
         "rollup-plugin-terser": "^5.3.0",
-        "rollup-plugin-vue": "^6.0.0-beta.6",
+        "rollup-plugin-vue": "^6.0.0-beta.10",
         "rollup-plugin-web-worker-loader": "^1.3.0",
+        "rollup-pluginutils": "^2.8.2",
         "selfsigned": "^1.10.7",
         "slash": "^3.0.0",
-        "vue": "^3.0.0-beta.14",
+        "vue": "^3.0.0-rc.5",
         "ws": "^7.2.3"
       }
     },
     "vue": {
-      "version": "3.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.0-beta.18.tgz",
-      "integrity": "sha512-waevph9s+M/aBf4XJIjfwHlHH7SBEr29dTMqq6ymnp/qJQHsavLlQHjsWRcxkYJ5rKfM6omoW+G6EBRBDB05sA==",
+      "version": "3.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.0-rc.5.tgz",
+      "integrity": "sha512-8t8Y4sHMBGD5iLZ7JfBGmKBJlzesPoL+/nW9EV8s+4LwnKC4rGlRp+Lj2rcign4iQaj0GFaL7DrQ8IoOfVX6+w==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.0.0-beta.18",
-        "@vue/runtime-dom": "3.0.0-beta.18",
-        "@vue/shared": "3.0.0-beta.18"
+        "@vue/compiler-dom": "3.0.0-rc.5",
+        "@vue/runtime-dom": "3.0.0-rc.5",
+        "@vue/shared": "3.0.0-rc.5"
       }
     },
     "wcwidth": {
@@ -5121,9 +5110,9 @@
       }
     },
     "ws": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "markdown-it": "^11.0.0"
   },
   "peerDependencies": {
-    "vite": ">=1.0.0-beta.1"
+    "vite": ">=1.0.0-rc.4"
   },
   "devDependencies": {
     "@babel/core": "7.11.1",
@@ -48,6 +48,6 @@
     "cypress": "4.12.1",
     "eslint": "7.7.0",
     "typescript": "3.9.7",
-    "vite": "1.0.0-beta.11"
+    "vite": "^1.0.0-rc.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import Frontmatter from 'front-matter'
 import MarkdownIt from 'markdown-it'
-import { Transform } from 'vite'
+import { Transform, Plugin } from 'vite'
 import { parseDOM, DomUtils } from 'htmlparser2'
 import { Element, Node as DomHandlerNode } from 'domhandler'
 
@@ -159,7 +159,7 @@ const transform = (options: PluginOptions): Transform => {
   }
 }
 
-module.exports = (options: PluginOptions = {}) => {
+export const markdownPlugin = (options: PluginOptions = {}): Plugin => {
   return {
     transforms: [transform(options)]
   }


### PR DESCRIPTION
Now `dist/index.d.ts` has no type definition for `module.exports`.
Also, since there is a `module.exports = `, `export enum Mode` is not actually exported. (`module.exports` overwrites `exports.～`)

This PR changes `module.exports = plugin` to `export plugin`.
This will fix them.

This PR causes a breaking change because `import mdPlugin from 'vite-plugin-markdown'` will not work after merging this.

To avoid a breaking change, replacing `module.exports = plugin` to `exports = plugin` will add type definition for `module.exports`.
But this makes `export enum Mode` and `export interface PluginOptions` impossible.
Changing `enum Mode` to a union type of string literal (like `'toc' | 'html'`) will solve about `export enum Mode` but I think there is no way to export `PluginOptions`.
Maybe exporting in another file solves it.
