### PR TITLE
Fix the example of type declaration for typescript users

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,14 +233,15 @@ declare module '*.md' {
 
   // When "Mode.React" is requested. VFC could take a generic like React.VFC<{ MyComponent: TypeOfMyComponent }>
   import React from 'react'
-  const react: React.VFC;
+  const ReactComponent: React.VFC;
   
   // When "Mode.Vue" is requested
-  import { ComponentOptions } from 'vue';
-  const vue: ComponentOptions;
+  import { ComponentOptions, Component } from 'vue';
+  const VueComponent: ComponentOptions;
+  const VueComponentWith: (components: Record<string, Component>) => ComponentOptions;
 
   // Modify below per your usage
-  export { attributes, toc, html, react, vue };
+  export { attributes, toc, html, ReactComponent, VueComponent, VueComponentWith };
 }
 ```
 


### PR DESCRIPTION
Because the original example would make typescript users confused and get errors.

So I changed the example's named export as you can check in commit's diff.

Thanks for the awesome vite markdown plugin!