### PR TITLE
Compatible highlight libs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,8 @@ const tf = (code: string, id: string, options: PluginOptions): TransformResult =
   if (options.mode?.includes(Mode.REACT)) {
     const root = parseDOM(html, { lowerCaseTags: false })
     const subComponentNamespace = 'SubReactComponent'
-
+    const codeFragments = []
+    
     const markCodeAsPre = (node: DomHandlerNode): void => {
       if (node instanceof Element) {
         if (node.tagName.match(/^[A-Z].+/)) {
@@ -93,7 +94,8 @@ const tf = (code: string, id: string, options: PluginOptions): TransformResult =
 
         if (node.tagName === 'code') {
           const codeContent = DomUtils.getInnerHTML(node, { decodeEntities: true })
-          node.attribs.dangerouslySetInnerHTML = `vfm{{ __html: \`${codeContent.replace(/([\\`])/g, '\\$1')}\`}}vfm`
+          codeFragments.push(codeContent)
+          node.attribs.dangerouslySetInnerHTML = `vfm`;
           node.childNodes = []
         }
 
@@ -104,7 +106,8 @@ const tf = (code: string, id: string, options: PluginOptions): TransformResult =
     }
     root.forEach(markCodeAsPre)
 
-    const h = DomUtils.getOuterHTML(root, { selfClosingTags: true }).replace(/"vfm{{/g, '{{').replace(/}}vfm"/g, '}}')
+    const h = DomUtils.getOuterHTML(root, { selfClosingTags: true })
+      .replace(/dangerouslySetInnerHTML="vfm"/g, item => `dangerouslySetInnerHTML={{__html: \`${codeFragments.shift()}\`}}`)
 
     const reactCode = `
       const markdown =

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ const tf = (code: string, id: string, options: PluginOptions): TransformResult =
         if (node.tagName === 'code') {
           const codeContent = DomUtils.getInnerHTML(node, { decodeEntities: true })
           codeFragments.push(codeContent)
-          node.attribs.dangerouslySetInnerHTML = 'vfm';
+          node.attribs.dangerouslySetInnerHTML = 'vfm'
           node.childNodes = []
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ const tf = (code: string, id: string, options: PluginOptions): TransformResult =
         if (node.tagName === 'code') {
           const codeContent = DomUtils.getInnerHTML(node, { decodeEntities: true })
           codeFragments.push(codeContent)
-          node.attribs.dangerouslySetInnerHTML = `vfm`;
+          node.attribs.dangerouslySetInnerHTML = 'vfm';
           node.childNodes = []
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ const tf = (code: string, id: string, options: PluginOptions): TransformResult =
   if (options.mode?.includes(Mode.REACT)) {
     const root = parseDOM(html, { lowerCaseTags: false })
     const subComponentNamespace = 'SubReactComponent'
-    const codeFragments = []
+    const codeFragments: string[] = []
     
     const markCodeAsPre = (node: DomHandlerNode): void => {
       if (node instanceof Element) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ const tf = (code: string, id: string, options: PluginOptions): TransformResult =
     root.forEach(markCodeAsPre)
 
     const h = DomUtils.getOuterHTML(root, { selfClosingTags: true })
-      .replace(/dangerouslySetInnerHTML="vfm"/g, item => `dangerouslySetInnerHTML={{__html: \`${codeFragments.shift()}\`}}`)
+      .replace(/dangerouslySetInnerHTML="vfm"/g, () => `dangerouslySetInnerHTML={{__html: \`${codeFragments.shift()}\`}}`)
 
     const reactCode = `
       const markdown =


### PR DESCRIPTION
### Problem

When I render markdown in react mode with **prism.js**, I found that codes which rendered by **prism.js** is encoded as HTML entities.

I think vue mode maybe have the same issue but I didn't have time to test it.

### Configuration

```js
import { defineConfig } from 'vite';
import react from '@vitejs/plugin-react';
import { Mode, plugin as markdown } from 'vite-plugin-markdown'
import markdownIt from 'markdown-it';
import markdownItPrism from 'markdown-it-prism';

export default defineConfig({
  plugins: [
    react(),
    markdown({
      mode: [Mode.REACT],
      markdownIt: markdownIt({ html: true }).use(markdownItPrism)
    })
  ]
})

```

### Input

~~~
```bash
npm install
```
~~~


### Output without prism.js

```html
<code class="language-bash">
npm install
</code>
```

### Expected Output with prism.js

```html
<code class="language-bash">
<span class="token function">npm</span> install
</code>
```

### Actual Output with prism.js

```html
<code class="language-bash">
&lt;span class=&quot;token function&quot;&lt;npm&lt;/span&lt; install
</code>
```