### PR TITLE
Adding option to import MD as MarkdownIt's tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ console.log(attributes) //=> { title: 'Awesome Title', description: 'Describe th
 ### Options
 
 ```ts
-mode?: ('html' | 'toc' | 'react' | 'vue')[]
+mode?: ('html' | 'toc' | 'tokens' | 'react' | 'vue')[]
 markdown?: (body: string) => string
 markdownIt?: MarkdownIt | MarkdownIt.Options
 ```
@@ -66,11 +66,12 @@ import { Mode } from 'vite-plugin-markdown'
 
 console.log(Mode.HTML) //=> 'html'
 console.log(Mode.TOC) //=> 'toc'
+console.log(Mode.TOKENS) //=> 'tokens'
 console.log(Mode.REACT) //=> 'react'
 console.log(Mode.VUE) //=> 'vue'
 ```
 
-"Mode" enables you to import markdown file in various formats (HTML, ToC, React/Vue Component)
+"Mode" enables you to import markdown file in various formats (HTML, ToC, Tokens, React/Vue Component)
 
 #### `Mode.HTML`
 
@@ -216,6 +217,31 @@ export default {
 </details>
 </details>
 
+#### `Mode.TOKENS`
+
+<details>
+  <summary>Import as parsed markdown tokens from MarkdownIt</summary>
+
+```md
+# vite
+
+Vite is an opinionated web dev build tool that serves your code via native ES Module imports during dev and bundles it with Rollup for production.
+
+## Status
+
+## Getting Started
+
+# Notes
+```
+
+```ts
+import { tokens } from './contents/the-doc.md'
+
+console.log(tokens) //=> [{ type: 'heading_open', tag: 'h1', ... }, ...]
+```
+
+</details>
+
 ### Type declarations
 
 In TypeScript project, need to declare typedefs for `.md` file as you need.
@@ -231,6 +257,10 @@ declare module '*.md' {
   // When "Mode.HTML" is requested
   const html: string;
 
+  // When "Mode.Tokens" is requested
+  import Token from 'markdown-it/lib/token'
+  const tokens: Token[];
+
   // When "Mode.React" is requested. VFC could take a generic like React.VFC<{ MyComponent: TypeOfMyComponent }>
   import React from 'react'
   const ReactComponent: React.VFC;
@@ -241,7 +271,7 @@ declare module '*.md' {
   const VueComponentWith: (components: Record<string, Component>) => ComponentOptions;
 
   // Modify below per your usage
-  export { attributes, toc, html, ReactComponent, VueComponent, VueComponentWith };
+  export { attributes, toc, html, tokens, ReactComponent, VueComponent, VueComponentWith };
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { Element, Node as DomHandlerNode } from 'domhandler'
 export enum Mode {
   TOC = 'toc',
   HTML = 'html',
+  TOKENS = 'tokens',
   REACT = 'react',
   VUE = 'vue',
 }
@@ -56,7 +57,8 @@ const tf = (code: string, id: string, options: PluginOptions): TransformResult =
   content.addContext(`const attributes = ${JSON.stringify(fm.attributes)}`)
   content.addExporting('attributes')
 
-  const html = markdownCompiler(options).render(fm.body)
+  const compiler = markdownCompiler(options)
+  const html = compiler.render(fm.body)
   if (options.mode?.includes(Mode.HTML)) {
     content.addContext(`const html = ${JSON.stringify(html)}`)
     content.addExporting('html')
@@ -75,6 +77,12 @@ const tf = (code: string, id: string, options: PluginOptions): TransformResult =
 
     content.addContext(`const toc = ${JSON.stringify(toc)}`)
     content.addExporting('toc')
+  }
+
+  if (options.mode?.includes(Mode.TOKENS) && compiler instanceof MarkdownIt) {
+    const tokens = compiler.parse(fm.body, {})
+    content.addContext(`const tokens = ${JSON.stringify(tokens)}`)
+    content.addExporting('tokens')
   }
 
   if (options.mode?.includes(Mode.REACT)) {


### PR DESCRIPTION
This should be useful in case you want to implement some sort of custom renderer for the markdown, currently, the only way to do this would be to parse the generated html client-side with `htmlparser2` or something like that, which is not ideal performance wise