### PR TITLE
fix order of ranges  in peer deps' logical or

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "markdown-it": "^12.0.0"
   },
   "peerDependencies": {
-    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "vite": "^4.0.0 || ^3.0.0 || ^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.21.0",


### PR DESCRIPTION
The correct order is required to install the package in Vite 4 without using `--force`